### PR TITLE
Add support for multiple configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"onCommand:xcodebuild-tools.profile",
 		"onCommand:xcodebuild-tools.run",
 		"onCommand:xcodebuild-tools.kill",
+		"onCommand:xcodebuild-tools.selectConfiguration",
 		"onCommand:xcodebuild-tools.selectBuildConfiguration",
 		"onCommand:xcodebuild-tools.selectDebugConfiguration",
 		"onCommand:xcodebuild-tools.openXcode",
@@ -81,6 +82,11 @@
 				"category": "Xcodebuild-tools"
 			},
 			{
+				"command": "xcodebuild-tools.selectConfiguration",
+				"title": "Select Configuration",
+				"category": "Xcodebuild-tools"
+			},
+			{
 				"command": "xcodebuild-tools.openXcode",
 				"title": "Open Xcode",
 				"category": "Xcodebuild-tools"
@@ -115,7 +121,7 @@
 	},
 	"devDependencies": {
 		"@types/mocha": "^2.2.41",
-		"@types/node": "^8.0.15",
+		"@types/node": "^8.10.42",
 		"mocha": "^3.4.2",
 		"typescript": "^2.4.2",
 		"vscode": "^1.1.10"

--- a/schemas/xcodebuild-tools-schema.json
+++ b/schemas/xcodebuild-tools-schema.json
@@ -23,9 +23,7 @@
             },
             "required": [
                 "name",
-                "program",
-                "args",
-                "cwd"
+                "program"
             ]
         },
         "variables": {
@@ -49,44 +47,60 @@
             "items": { 
                 "$ref": "#/definitions/task" 
             }
-        }
-    },
+        },
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "sdk": {
+                    "type": "string",
+                    "description": "name or path of the base SDK"
+                },
+                "workspace": {
+                    "type": "string",
+                    "description": "path to Xcode workspace"
+                },
+                "scheme": {
+                    "type": "string",
+                    "description": "name of Xcode scheme"
+                },
+                "preBuildTasks": { 
+                    "$ref": "#/definitions/tasks" 
+                },        
+                "postBuildTasks": { 
+                    "$ref": "#/definitions/tasks" 
+                },
+                "debugConfigurations": { 
+                    "$ref": "#/definitions/tasks" 
+                },
+                "variables": {
+                    "$ref": "#/definitions/variables"
+                },
+                "env": {
+                    "$ref": "#/definitions/variables"
+                },
+                "args": {
+                    "$ref": "#/definitions/args"
+                }
+            },
 
-    "type": "object",
-    "properties": {
-        "sdk": {
-            "type": "string",
-            "description": "name or path of the base SDK"
+            "required": [
+                "workspace",
+                "scheme"
+            ]
         },
-        "workspace": {
-            "type": "string",
-            "description": "path to Xcode workspace"
-        },
-        "scheme": {
-            "type": "string",
-            "description": "name of Xcode scheme"
-        },
-        "preBuildTasks": { 
-            "$ref": "#/definitions/tasks" 
-        },        
-        "postBuildTasks": { 
-            "$ref": "#/definitions/tasks" 
-        },
-        "debugConfigurations": { 
-            "$ref": "#/definitions/tasks" 
-        },
-        "variables": {
-            "$ref": "#/definitions/variables"
-        },
-        "env": {
-            "$ref": "#/definitions/variables"
-        },
-        "args": {
-            "$ref": "#/definitions/args"
+        "configurationsArray": {
+            "type": "array",
+            "items": { 
+                "$ref": "#/definitions/configuration" 
+            }
         }
     },
-    "required": [
-        "workspace",
-        "scheme"
+    "oneOf": [
+        {
+            "$ref": "#/definitions/configuration"
+        },
+        {
+            "$ref": "#/definitions/configurationsArray"
+        }
     ]
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -6,6 +6,9 @@ export class StatusBar
     private buildStatusItem =
         vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5.04);
 
+        private configStatusItem =
+        vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5.035);
+
     private buildConfigStatusItem =
         vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5.03);
 
@@ -14,6 +17,7 @@ export class StatusBar
 
     private runStatusItem =
         vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5.02);
+
 
     private debugConfigStatusItem =
         vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 5.01);
@@ -38,6 +42,9 @@ export class StatusBar
         this.runStatusItem.tooltip = "Click to run (without debugging) the selected debug configuration";
         this.runStatusItem.text = "$(triangle-right)";
 
+        this.configStatusItem.command = "xcodebuild-tools.selectConfiguration";
+        this.configStatusItem.tooltip = "Click to select the workspace and scheme";
+
         this.debugConfigStatusItem.command = "xcodebuild-tools.selectDebugConfiguration";
         this.debugConfigStatusItem.tooltip = "Click to select the debug configuration";
 
@@ -52,6 +59,7 @@ export class StatusBar
         f(this.buildConfigStatusItem);
         f(this.debugStatusItem);
         f(this.runStatusItem);
+        f(this.configStatusItem);
         f(this.debugConfigStatusItem);
         f(this.killStatusItem);
     }
@@ -71,8 +79,9 @@ export class StatusBar
         this.forallItems(i => i.hide());
     }
 
-    public update(buildConfig: string, debugConfig:string)
+    public update(config: string, buildConfig: string, debugConfig:string)
     {
+        this.configStatusItem.text = config;
         this.buildConfigStatusItem.text = buildConfig;
         this.debugConfigStatusItem.text = debugConfig;
 


### PR DESCRIPTION
This change allows having array of configurations or a single configuration in xcodebuild-tools.json
UI picker is provided to switch active configuration (workspace/scheme)
Selection of active debug and build configuration is preserved per-project