### PR TITLE
remove macOS only phrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Feedback is highy appreciated! Let me know if this works for you? Are there any 
 ## Caveats
 
 * First release, my first non-trivial TypeScript/JavaScript program - expect bugs, problems, and non-idiomatic code.
-* Only useful for macOS apps at this point.
+* Minimal support for iOS apps.
 * Managing the project (adding files, changing settings, etc.) has to be done using Xcode itself.
 
 ## Features


### PR DESCRIPTION
This line almost scared me away before I realized that there was an example at the bottom of the readme.

If you would prefer to remove the bullet completely rather than "minimal support", I can make that change too. I chose to add it because deploying to a device is not supported, and there are open issues around debugging.